### PR TITLE
Refactor

### DIFF
--- a/src/DotEnv.jl
+++ b/src/DotEnv.jl
@@ -13,8 +13,7 @@ function parse( src )
             key = m.captures[1]
             value = string(m.captures[2])
 
-            len = value != "" ? length(value) : 0
-            if (len > 0 && value[1] === '"' && value[end] === '"')
+            if (length(value) > 0 && value[1] === '"' && value[end] === '"')
                 value = replace(value, r"\\n"m => "\n")
             end
 


### PR DESCRIPTION
Since `length("")` is 0, there is not a need for the ternary conditional. We can directly use `length(value) > 0` in the if's conditional, which will make the context clear that we are using it to guard for `value[1]` and `value[end]`.