### PR TITLE
Fix config warning

### DIFF
--- a/src/DotEnv.jl
+++ b/src/DotEnv.jl
@@ -32,7 +32,7 @@ end
 `config` reads your .env file, parse the content, stores it to `ENV`,
 and finally return a Dict with the content.
 """
-function config( path=".env" )
+function config( path )
     if (isfile(path))
         parsed = parse(String(read(path)))
 


### PR DESCRIPTION
Resolves #5 

There is a need to support all 3 of the following:-
1. `config()` reads from `.env`.
1. `config("custom.env")` reads from `custom.env`.
1. `config(path="custom.env")` reads from `custom.env`.

We can achieve this by defining just `config(path)` and `config(; path=".env")`.