### PR TITLE
Fixed warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+
+# Pkg.jl files
+Manifest.toml
+
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DotEnv"
 uuid = "4dc1fcf4-5e3b-5448-94ab-0c38ec0385c1"
 authors = ["Valentín Mari"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 

--- a/src/DotEnv.jl
+++ b/src/DotEnv.jl
@@ -43,7 +43,7 @@ end
 `config` reads your .env file, parse the content, stores it to `ENV`,
 and finally return a Dict with the content.
 """
-function config( path=".env", override = false)
+function config( path, override = false)
     if (isfile(path))
         parsed = parse(read(path, String))
 
@@ -59,8 +59,8 @@ function config( path=".env", override = false)
     end
 end
 
-config( ;path=".env", override = true ) = config(path, override)
+config( ;path=".env", override = false ) = config(path, override)
 
-load(opts...) = config(opts...)
+load(opts...; kwargs...) = config(opts...; kwargs...)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,9 @@ println("Testing DotEnv")
 
 const dir = dirname(@__FILE__)
 
+# There is no "USER" variable on windows.
+initial_value = haskey(ENV, "USER") ? ENV["USER"] : "WINDOWS"
+ENV["USER"] = initial_value
 
 @testset "basic" begin
     #basic input
@@ -31,22 +34,13 @@ const dir = dirname(@__FILE__)
     @test length(DotEnv.config(file2).dict) === 10
 
     #shouldn't replace ENV vars
-    previous_value = ENV["USER"]
     cfg = DotEnv.config(file)
 
     @test ENV["USER"] != cfg["USER"]
-    @test ENV["USER"] == previous_value
+    @test ENV["USER"] == initial_value
 
     #appropiately loaded into ENV if CUSTOM_VAL is non existent
     @test ENV["CUSTOMVAL123"] == "yes"
-
-    # Can force override
-    cfg = DotEnv.config(file, true)
-    @test ENV["USER"] == cfg["USER"]
-    @test ENV["USER"] == "replaced value"
-    
-    # Restore previous environment
-    ENV["USER"] = previous_value
 
     # Test that EnvDict is reading from ENV
     ENV["SOME_RANDOM_KEY"] = "abc"
@@ -58,6 +52,19 @@ const dir = dirname(@__FILE__)
     #test alias
     @test DotEnv.load(file).dict == DotEnv.config(file).dict
     @test DotEnv.load(; path = file).dict == DotEnv.config(file).dict
+end
+
+@testset "Override" begin
+    #basic input
+    file = joinpath(dir, ".env.override")
+
+    # Can force override
+    cfg = DotEnv.config(file, true)
+    @test ENV["USER"] == cfg["USER"]
+    @test ENV["USER"] == "replaced value"
+    
+    # Restore previous environment
+    ENV["USER"] = initial_value
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,7 @@ const dir = dirname(@__FILE__)
 
     #test alias
     @test DotEnv.load(file).dict == DotEnv.config(file).dict
+    @test DotEnv.load(; path = file).dict == DotEnv.config(file).dict
 end
 
 


### PR DESCRIPTION
Well, since everything went so smoothly with the previous PR, here some more improvements

1. Warning removed (https://github.com/vmari/DotEnv.jl/issues/5), this fix also duplicates https://github.com/vmari/DotEnv.jl/pull/7
2. Extended `load` definition, now it supports `kwargs` in the same manner as `config`.
3. Synchronized `override` options in `kwargs` and `args` versions.
4. Added `Manifest.toml`, so this PR also duplicates https://github.com/vmari/DotEnv.jl/pull/6
